### PR TITLE
ci: :construction_worker: build to "gh-pages" for now

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -5,8 +5,16 @@ on:
     branches:
       - main
 
+# Limit permissions to minimal needed.
+permissions: read-all
+
 jobs:
   build-deploy-docs:
     uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
+    permissions:
+      contents: write
+      pages: write
+    with:
+      hosting-provider: 'gh-pages'
     secrets:
-      netlify-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

We will eventually host the website on Netlify, but for now, it's faster to get it hosted on GitHub Pages.

No review needed.

## Checklist

- [x] Ran `just run-all`
